### PR TITLE
Fix for docker

### DIFF
--- a/eWeLink_Smart_Home/dist/config/url.js
+++ b/eWeLink_Smart_Home/dist/config/url.js
@@ -8,7 +8,7 @@ var process_1 = __importDefault(require("process"));
 var config_1 = require("./config");
 var url = 'http://homeassistant:8123';
 if (!config_1.debugMode && config_1.isSupervisor) {
-    url = 'http://supervisor/core';
+    url = process_1.default.env.HA_URL ? process_1.default.env.HA_URL : 'http://supervisor/core';
 }
 if (!config_1.debugMode && !config_1.isSupervisor) {
     url = process_1.default.env.HA_URL;

--- a/eWeLink_Smart_Home/dist/lib-ha/WebSocket2Ha.js
+++ b/eWeLink_Smart_Home/dist/lib-ha/WebSocket2Ha.js
@@ -104,7 +104,7 @@ var WebSocket2Ha = (function () {
         this.wsUrl = '';
         this.connected = false;
         this.cmdId = 1;
-        this.wsUrl = process_1.default.env.DEBUG_MODE ? process_1.default.env.HASS_WS_URL : 'http://supervisor/core/websocket';
+        this.wsUrl = process_1.default.env.DEBUG_MODE ? process_1.default.env.HASS_WS_URL : process_1.default.env.HA_URL ? process_1.default.env.HA_URL + '/api/websocket'  : 'http://supervisor/core/websocket';
         this.connect();
     }
     WebSocket2Ha.prototype.connect = function () {

--- a/eWeLink_Smart_Home/dist/middleware/redirectToAuth.js
+++ b/eWeLink_Smart_Home/dist/middleware/redirectToAuth.js
@@ -70,7 +70,7 @@ exports.default = (function (req, res, next) { return __awaiter(void 0, void 0, 
         if (config_1.isSupervisor) {
             res.json({
                 error: 302,
-                data: 'http://homeassistant:8123',
+                data: process_1.default.env.HA_URL ? process_1.default.env.HA_URL : 'http://homeassistant:8123',
             });
         }
         else {


### PR DESCRIPTION
The current version has hardcoded urls to the supervisor and the mDNS name of homeassistant.
This fix solves the conflicts. 

Testing has been done on dockerized HomeAssistant but no testing on HomeAssistantOS