### PR TITLE
Fix - Add-on fails to install due to docker build fail.

### DIFF
--- a/eWeLink_Smart_Home/Dockerfile
+++ b/eWeLink_Smart_Home/Dockerfile
@@ -1,9 +1,10 @@
 # ARG BUILD_FROM
 # FROM $BUILD_FROM
 
-FROM node:14-slim
+FROM node:18-slim
+
 ENV CK_API_ENV=prod
-RUN apt-get update && apt-get install -y python build-essential
+RUN apt-get update && apt-get install -y python3 build-essential
 RUN mkdir -p /workspace/node_modules
 COPY ["./dist", "./package.json", "/workspace/"]
 WORKDIR /workspace


### PR DESCRIPTION
This PR updates the base image from node:14-slim to node:18-slim in order to fix the installation/build failure.

The issue with the current base image (node:14-slim) is that it relies on Debian Buster, whose repositories are no longer available or maintained. As a result, apt-get update fails, breaking the Docker build process.

By switching to node:18-slim, which uses a newer and supported version of Debian, the build process succeeds again. Additionally, python was replaced with python3 to ensure compatibility with modern Debian packages.