### PR TITLE
feat(1.4.7): add rgb support for ha-lib

### DIFF
--- a/eWeLink_Smart_Home/config.json
+++ b/eWeLink_Smart_Home/config.json
@@ -1,6 +1,6 @@
 {
     "name": "eWeLink Smart Home",
-    "version": "1.4.6",
+    "version": "1.4.7",
     "slug": "ewelink_smart_home_slug",
     "description": "connect eWeLink with home-assistant",
     "arch": ["armhf", "armv7", "aarch64", "amd64", "i386"],

--- a/eWeLink_Smart_Home/dist/lib-ha/const.js
+++ b/eWeLink_Smart_Home/dist/lib-ha/const.js
@@ -19,6 +19,7 @@ exports.HA_SERVICE_LIGHT_TURN_OFF = 'light.turn_off';
 exports.HA_COLOR_MODE_COLOR_TEMP = 'color_temp';
 exports.HA_COLOR_MODE_XY = 'xy';
 exports.HA_COLOR_MODE_HS = 'hs';
+exports.HA_COLOR_MODE_RGB = 'rgb';
 exports.HA_COLOR_MODE_BRIGHTNESS = 'brightness';
 exports.HA_BRIGHTNESS_MAX = 255;
 exports.CK_COLOR_TEMP_MIN = 0;

--- a/eWeLink_Smart_Home/dist/lib-ha/utils.js
+++ b/eWeLink_Smart_Home/dist/lib-ha/utils.js
@@ -62,8 +62,9 @@ function getHaDeviceUiid(data) {
                 finally { if (e_2) throw e_2.error; }
             }
             var supportedColorMode = lightEntity === null || lightEntity === void 0 ? void 0 : lightEntity.entityState.attributes.supported_color_modes;
-            if (supportedColorMode.includes(const_1.HA_COLOR_MODE_COLOR_TEMP)
-                && (supportedColorMode.includes(const_1.HA_COLOR_MODE_XY) || supportedColorMode.includes(const_1.HA_COLOR_MODE_HS))) {
+            logger_1.logger.info("getHaDeviceUiid(): light supportedColorMode: ".concat(JSON.stringify(supportedColorMode)));
+            if ((supportedColorMode.includes(const_1.HA_COLOR_MODE_COLOR_TEMP)
+                && supportedColorMode.includes(const_1.HA_COLOR_MODE_XY)) || supportedColorMode.includes(const_1.HA_COLOR_MODE_RGB)) {
                 return const_1.CK_UIID_20008;
             }
             else if (supportedColorMode.includes(const_1.HA_COLOR_MODE_COLOR_TEMP)) {


### PR DESCRIPTION
Add support for wled and esphome rgb led strip sync support for ewelink app.
wled and esphome home assistant device provide 'rgb' color_mode for ligth device. In ewelink app appears as simple on-off light, cannot be change color or brightness. 